### PR TITLE
Upgrade to latest Bouncy Castle

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add this to your pom.xml file:
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.54</version>
+            <version>1.55</version>
         </dependency>
 
 

--- a/openpdf/pom.xml
+++ b/openpdf/pom.xml
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.54</version>
+            <version>1.55</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.54</version>
+            <version>1.55</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
The latest version includes some bug fixes and improvements: http://www.bouncycastle.org/releasenotes.html. They might not be relevant to OpenPDF, but it would be nice to always use the latest release available.
